### PR TITLE
Handle subscores in Prediction for GEPA

### DIFF
--- a/dspy/primitives/prediction.py
+++ b/dspy/primitives/prediction.py
@@ -18,11 +18,24 @@ class Prediction(Example):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Example sets a few helper attributes that are not relevant for a
+        # prediction object.  They can contain objects (e.g., History
+        # instances) that Pydantic struggles to serialise which then surface as
+        # warnings when GEPA tries to log `Prediction` instances.  We drop
+        # these helpers early to keep the internal store clean and JSON
+        # serialisable.
         del self._demos
         del self._input_keys
 
         self._completions = None
         self._lm_usage = None
+
+        # Newer GEPA metrics can return fine‑grained ``subscores`` in addition
+        # to a top level score.  `Example` happily stores any field, but callers
+        # expect ``subscores`` to at least be present and behave like a
+        # dictionary.  Initialising it here avoids attribute errors and keeps
+        # serialisation stable even if a metric forgets to supply the field.
+        self._store.setdefault("subscores", {})
 
     def get_lm_usage(self):
         return self._lm_usage
@@ -116,6 +129,22 @@ class Prediction(Example):
     @property
     def completions(self):
         return self._completions
+
+    # Convenience accessors for subscores ---------------------------------
+    @property
+    def subscores(self):  # pragma: no cover - simple delegation
+        """Return any metric subscores associated with this prediction.
+
+        The attribute lives inside the underlying ``Example`` store; exposing
+        it as a property gives callers a stable interface and keeps pydantic
+        from complaining when the field is missing.
+        """
+
+        return self._store.setdefault("subscores", {})
+
+    @subscores.setter
+    def subscores(self, value):  # pragma: no cover - simple delegation
+        self._store["subscores"] = value or {}
 
 
 class Completions:

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -23,9 +23,24 @@ DSPyTrace = list[tuple[Any, dict[str, Any], Prediction]]
 
 
 class ScoreWithFeedback(Prediction):
-    score: float
-    subscores: dict[str, float]
-    feedback: str
+    """Prediction enriched with feedback and per-component subscores.
+
+    ``Prediction`` itself happily stores arbitrary fields inside its internal
+    dictionary.  Defining an explicit ``__init__`` here provides a clear
+    interface and, importantly, ensures that ``subscores`` is always a
+    dictionary.  Pydantic can otherwise emit warnings when it encounters a
+    missing field during serialisation.
+    """
+
+    def __init__(
+        self,
+        *,
+        score: float,
+        subscores: dict[str, float] | None = None,
+        feedback: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(score=score, feedback=feedback, subscores=subscores or {}, **kwargs)
 
 
 class PredictorFeedbackFn(Protocol):
@@ -117,9 +132,18 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                     else:
                         subscores.append({})
 
-            return EvaluationBatch(
-                outputs=outputs, scores=scores, subscores=subscores, trajectories=trajs
-            )
+            # Newer versions of GEPA's EvaluationBatch include an optional
+            # ``subscores`` field.  Older releases do not.  To keep DSPy
+            # compatible with both we inspect the dataclass at runtime and only
+            # pass the field when it is supported.
+            if "subscores" in getattr(EvaluationBatch, "__annotations__", {}):
+                return EvaluationBatch(
+                    outputs=outputs,
+                    scores=scores,
+                    subscores=subscores,
+                    trajectories=trajs,
+                )
+            return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajs)
         else:
             evaluator = Evaluate(
                 devset=batch,
@@ -140,9 +164,14 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
             ]
             subscores = subscores if any(subscores) else None
 
-            return EvaluationBatch(
-                outputs=outputs, scores=scores, subscores=subscores, trajectories=None
-            )
+            if "subscores" in getattr(EvaluationBatch, "__annotations__", {}):
+                return EvaluationBatch(
+                    outputs=outputs,
+                    scores=scores,
+                    subscores=subscores,
+                    trajectories=None,
+                )
+            return EvaluationBatch(outputs=outputs, scores=scores, trajectories=None)
 
     def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
         from ..bootstrap_finetune import FailedPrediction


### PR DESCRIPTION
## Summary
- ensure `Prediction` always includes a subscores dictionary and expose it via a property
- extend `ScoreWithFeedback` to normalise subscores and avoid missing fields
- only pass subscores to `EvaluationBatch` when supported

## Testing
- `pytest tests/teleprompt/test_gepa_objective.py -q` *(fails: Couldn't reach 'AI-MO/aimo-validation-aime')*


------
https://chatgpt.com/codex/tasks/task_e_68a1f8dad35c832da264c953bbf7bbf0