### PR TITLE
Support GEPA objective and hybrid frontier tracking

### DIFF
--- a/docs/docs/api/optimizers/GEPA/overview.md
+++ b/docs/docs/api/optimizers/GEPA/overview.md
@@ -40,6 +40,14 @@ One of the key insights behind GEPA is its ability to leverage domain-specific t
 <!-- END_API_REF -->
 
 When `track_stats=True`, GEPA returns detailed results about all of the proposed candidates, and metadata about the optimization run. The results are available in the `detailed_results` attribute of the optimized program returned by GEPA, and has the following type:
+
+!!! tip "Pareto frontier tracking modes"
+    GEPA now supports three tracking modes controlled by the `frontier_type` argument (`"instance"`, `"objective"`, or `"hybrid"`).
+    Instance tracking matches the classic behavior of maintaining a Pareto frontier over validation examples. Objective
+    tracking aggregates the metric subscores you declare via `dspy.metrics.subscore`, enabling multi-objective optimization.
+    Hybrid tracking combines both views, keeping the best candidates per objective and per validation example simultaneously.
+    The resulting `DspyGEPAResult` exposes `frontier_dimension_labels` so you can interpret each tracked dimension.
+
 <!-- START_API_REF -->
 ::: dspy.teleprompt.gepa.gepa.DspyGEPAResult
     handler: python
@@ -64,10 +72,13 @@ See GEPA usage tutorials in [GEPA Tutorials](../../../tutorials/gepa_ai_program/
 GEPA can act as a test-time/inference search mechanism. By setting your `valset` to your _evaluation batch_ and using `track_best_outputs=True`, GEPA produces for each batch element the highest-scoring outputs found during the evolutionary search.
 
 ```python
-gepa = dspy.GEPA(metric=metric, track_stats=True, ...)
+gepa = dspy.GEPA(metric=metric, track_stats=True, frontier_type="hybrid", ...)
 new_prog = gepa.compile(student, trainset=my_tasks, valset=my_tasks)
-highest_score_achieved_per_task = new_prog.detailed_results.highest_score_achieved_per_val_task
+best_scores = new_prog.detailed_results.highest_score_achieved_per_frontier_dimension
 best_outputs = new_prog.detailed_results.best_outputs_valset
+
+for dimension, score in best_scores.items():
+    print(f"{dimension}: {score:.3f}")
 ```
 
 ## How Does GEPA Work?

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -76,7 +76,9 @@ class EvaluationResult(Prediction):
     - results: a list of (example, prediction, score) tuples for each example in devset
     """
 
-    def __init__(self, score: float, results: list[tuple["dspy.Example", "dspy.Example", Any]]):
+    def __init__(
+        self, score: float, results: list[tuple["dspy.Example", "dspy.Example", Any]]
+    ):
         super().__init__(score=score, results=results)
 
     def __repr__(self):
@@ -134,7 +136,9 @@ class Evaluate:
         self._metric_accepts_ctx_cache: dict[int, bool] = {}
 
         if "return_outputs" in kwargs:
-            raise ValueError("`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object.")
+            raise ValueError(
+                "`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object."
+            )
 
     @with_callbacks
     def __call__(
@@ -172,20 +176,30 @@ class Evaluate:
         metric = metric if metric is not None else self.metric
         devset = devset if devset is not None else self.devset
         num_threads = num_threads if num_threads is not None else self.num_threads
-        display_progress = display_progress if display_progress is not None else self.display_progress
-        display_table = display_table if display_table is not None else self.display_table
+        display_progress = (
+            display_progress if display_progress is not None else self.display_progress
+        )
+        display_table = (
+            display_table if display_table is not None else self.display_table
+        )
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
 
         if callback_metadata:
-            logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
+            logger.debug(
+                f"Evaluate is called with callback metadata: {callback_metadata}"
+            )
 
         tqdm.tqdm._instances.clear()
 
         executor = ParallelExecutor(
             num_threads=num_threads,
             disable_progress_bar=not display_progress,
-            max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
+            max_errors=(
+                self.max_errors
+                if self.max_errors is not None
+                else dspy.settings.max_errors
+            ),
             provide_traceback=self.provide_traceback,
             compare_results=True,
         )
@@ -196,7 +210,11 @@ class Evaluate:
             latency_ms = (time.perf_counter() - start_time) * 1000.0
 
             prediction_obj = _extract_prediction_object(prediction)
-            usage = prediction_obj.get_lm_usage() if isinstance(prediction_obj, Prediction) else None
+            usage = (
+                prediction_obj.get_lm_usage()
+                if isinstance(prediction_obj, Prediction)
+                else None
+            )
             ctx = EvaluationMetricContext(usage=usage, latency_ms=latency_ms)
 
             if isinstance(prediction_obj, Prediction):
@@ -212,23 +230,37 @@ class Evaluate:
         results = executor.execute(process_item, devset)
         assert len(devset) == len(results)
 
-        results = [((dspy.Prediction(), Score(self.failure_score)) if r is None else r) for r in results]
-        results = [(example, prediction, score) for example, (prediction, score) in zip(devset, results, strict=False)]
+        results = [
+            ((dspy.Prediction(), Score(self.failure_score)) if r is None else r)
+            for r in results
+        ]
+        results = [
+            (example, prediction, score)
+            for example, (prediction, score) in zip(devset, results, strict=False)
+        ]
         aggregates = [score.scalar for *_, score in results]
         ncorrect, ntotal = sum(aggregates), len(devset)
 
-        logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
+        logger.info(
+            f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)"
+        )
 
         if display_table:
             if importlib.util.find_spec("pandas") is not None:
                 # Rename the 'correct' column to the name of the metric object
-                metric_name = metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
+                metric_name = (
+                    metric.__name__
+                    if isinstance(metric, types.FunctionType)
+                    else metric.__class__.__name__
+                )
                 # Construct a pandas DataFrame from the results
                 result_df = self._construct_result_table(results, metric_name)
 
                 self._display_result_table(result_df, display_table, metric_name)
             else:
-                logger.warning("Skipping table display since `pandas` is not installed.")
+                logger.warning(
+                    "Skipping table display since `pandas` is not installed."
+                )
 
         if save_as_csv:
             metric_name = (
@@ -253,8 +285,8 @@ class Evaluate:
             )
             data = self._prepare_results_output(results, metric_name)
             with open(
-                    save_as_json,
-                    "w",
+                save_as_json,
+                "w",
             ) as f:
                 json.dump(data, f)
 
@@ -265,19 +297,31 @@ class Evaluate:
 
     @staticmethod
     def _prepare_results_output(
-            results: list[tuple["dspy.Example", "dspy.Example", Score]], metric_name: str
+        results: list[tuple["dspy.Example", "dspy.Example", Score]], metric_name: str
     ):
         return [
             (
-                merge_dicts(example, prediction) | _scores_to_row(score, metric_name)
+                merge_dicts(
+                    example.toDict(),
+                    (
+                        prediction.toDict()
+                        if hasattr(prediction, "toDict")
+                        else prediction
+                    ),
+                )
+                | _scores_to_row(score, metric_name)
                 if prediction_is_dictlike(prediction)
-                else dict(example) | {"prediction": prediction} | _scores_to_row(score, metric_name)
+                else example.toDict()
+                | {"prediction": prediction}
+                | _scores_to_row(score, metric_name)
             )
             for example, prediction, score in results
         ]
 
     def _construct_result_table(
-        self, results: list[tuple["dspy.Example", "dspy.Example", Score]], metric_name: str
+        self,
+        results: list[tuple["dspy.Example", "dspy.Example", Score]],
+        metric_name: str,
     ) -> "pd.DataFrame":
         """
         Construct a pandas DataFrame from the specified result list.
@@ -296,7 +340,11 @@ class Evaluate:
 
         # Truncate every cell in the DataFrame (DataFrame.applymap was renamed to DataFrame.map in Pandas 2.1.0)
         result_df = pd.DataFrame(data)
-        result_df = result_df.map(truncate_cell) if hasattr(result_df, "map") else result_df.applymap(truncate_cell)
+        result_df = (
+            result_df.map(truncate_cell)
+            if hasattr(result_df, "map")
+            else result_df.applymap(truncate_cell)
+        )
 
         return result_df.rename(columns={"correct": metric_name})
 
@@ -311,7 +359,9 @@ class Evaluate:
             if isinstance(prediction, Prediction):
                 scores = prediction.resolve_score(ctx)
                 if scores is None:
-                    raise ValueError("Prediction does not provide a score and no metric was supplied.")
+                    raise ValueError(
+                        "Prediction does not provide a score and no metric was supplied."
+                    )
                 return scores
             raise ValueError("No metric provided for evaluation.")
 
@@ -343,7 +393,9 @@ class Evaluate:
         self._metric_accepts_ctx_cache[cache_key] = accepts
         return accepts
 
-    def _display_result_table(self, result_df: "pd.DataFrame", display_table: bool | int, metric_name: str):
+    def _display_result_table(
+        self, result_df: "pd.DataFrame", display_table: bool | int, metric_name: str
+    ):
         """
         Display the specified result DataFrame in a table format.
 
@@ -430,7 +482,10 @@ def _callable_accepts_context(metric: Callable) -> bool:
 
     params = list(sig.parameters.values())
     for param in params:
-        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
             return True
     return len(params) >= 3
 
@@ -450,6 +505,7 @@ def stylize_metric_name(df: "pd.DataFrame", metric_name: str) -> "pd.DataFrame":
     :param df: The pandas DataFrame for which to stylize cell contents.
     :param metric_name: The name of the metric for which to stylize DataFrame cell contents.
     """
+
     def format_metric(x):
         if isinstance(x, float):
             return f"✔️ [{x:.3f}]"
@@ -457,6 +513,7 @@ def stylize_metric_name(df: "pd.DataFrame", metric_name: str) -> "pd.DataFrame":
             return f"✔️ [{x}]"
         else:
             return ""
+
     df[metric_name] = df[metric_name].apply(format_metric)
     return df
 
@@ -479,7 +536,9 @@ def display_dataframe(df: "pd.DataFrame"):
             print(df)
 
 
-def configure_dataframe_for_ipython_notebook_display(df: "pd.DataFrame") -> "pd.DataFrame":
+def configure_dataframe_for_ipython_notebook_display(
+    df: "pd.DataFrame",
+) -> "pd.DataFrame":
     """Set various pandas display options for DataFrame in an IPython notebook environment."""
     import pandas as pd
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pillow>=10.1.0",
     "numpy>=1.26.0",
     "xxhash>=3.5.0",
-    "gepa[dspy]==0.0.17",
+    "gepa[dspy] @ git+https://github.com/MatsErdkamp/gepa@f9056ebfc38c99f2bc2e6caa54b72af764d98c1b",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- expose the new GEPA frontier metadata in `DspyGEPAResult`, forward objective scores, and add a helper that reports best scores per tracked dimension
- allow choosing `frontier_type` when constructing `dspy.GEPA`, prevent conflicting overrides, and ensure evaluation batches propagate metric subscores for objective/hybrid tracking
- document the frontier modes, add coverage for subscore handling, and pin DSPy to the MatsErdkamp GEPA commit that contains the new functionality

## Testing
- pytest tests/teleprompt/test_gepa.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8ddb3f24832daa3f2d5da652e7bb